### PR TITLE
Automatically set promotion amount as discount

### DIFF
--- a/Action/FixedDiscountPromotionAction.php
+++ b/Action/FixedDiscountPromotionAction.php
@@ -31,7 +31,7 @@ class FixedDiscountPromotionAction implements PromotionActionInterface
     public function execute(OrderInterface $order, array $configuration)
     {
         $adjustment = $this->repository->createNew();
-        $adjustment->setAmount($configuration['amount']);
+        $adjustment->setAmount(-$configuration['amount']);
 
         $order->addAdjustment($adjustment);
     }


### PR DESCRIPTION
Shouldn't we set the adjustment amount to _minus_ the promotion amount?

When we fill in the promotion form we are welcomed to define a positive amount, to that it would make sense. Or maybe the right place of this minus is on the form?
