### PR TITLE
Update PercentageDiscountConfigurationType.php

### DIFF
--- a/Form/Type/Action/PercentageDiscountConfigurationType.php
+++ b/Form/Type/Action/PercentageDiscountConfigurationType.php
@@ -37,7 +37,7 @@ class PercentageDiscountConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('percentage', 'percent', array(
+            ->add('percentage', 'integer', array(
                 'label' => 'sylius.form.action.percentage_discount_configuration.percentage',
                 'constraints' => array(
                     new NotBlank(),


### PR DESCRIPTION
Hi,

i found this bug. When you create action with Percetage discount, Sylius saves discount in float format let's say: if you put 10% discount he saves it as 0.1, but when calculate discount it uses this formula:

$adjustment->setAmount(- $subject->getTotal() \* ($configuration['percentage'] / 100));

Also doesn't saves the name of adjusment for example name of the action.

Is it better solution to fix it in formula above, or to save discount as integer?

best,
Antonio
