### PR TITLE
Fix: coupon generation translation for 'amount'

### DIFF
--- a/Resources/translations/messages.nl.yml
+++ b/Resources/translations/messages.nl.yml
@@ -31,7 +31,7 @@ sylius:
             expires_at: Verloopt op
             usage_limit: Gebruikslimiet
         promotion_coupon_generator_instruction:
-            amount: Bedrag
+            amount: Aantal te genereren
             code_length: Lengte van de code
             expires_at: Verloopt op
             prefix: Voorvoegsel


### PR DESCRIPTION
The 'amount' key on the coupon generation page is automatically translated as a monetary amount. But in this context it reflects the number of coupon codes to be generated. 

I've PR'ed this for this one translation (dutch) only to verify if this is indeed an improper translation. 